### PR TITLE
Switch back from forked attr_encrypted to original repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,8 +88,7 @@ gem "faraday-cookie_jar",       "0.0.7"
 gem "faraday-follow_redirects", "0.3.0"
 
 # Authentication
-# See: https://pagertree.com/2021/04/13/rails-7-attr-encrypted-migration/
-gem "attr_encrypted", git: "https://github.com/PagerTree/attr_encrypted", branch: "rails-7-0-support"
+gem "attr_encrypted", "~> 4.0"
 gem "devise", "~>4.8.1"
 gem "devise-i18n", "~> 1.10", ">= 1.10.1"
 gem "devise_last_seen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/PagerTree/attr_encrypted
-  revision: df02ab0b9547220b2859317d1af8a4280b0fae44
-  branch: rails-7-0-support
-  specs:
-    attr_encrypted (3.1.0)
-      encryptor (~> 3.0.0)
-
-GIT
   remote: https://github.com/wangliyao/entypo-rails
   revision: 7ce3d376439209e33e64653ccf7223dea5a8b937
   specs:
@@ -86,6 +78,8 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    attr_encrypted (4.0.0)
+      encryptor (~> 3.0.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
     bcrypt (3.1.18)
@@ -479,7 +473,7 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on (~> 9.0, >= 9.0.1)
   addressable (~> 2.8)
-  attr_encrypted!
+  attr_encrypted (~> 4.0)
   bootsnap
   bootstrap (~> 5.1.3)
   brakeman (~> 5.2, >= 5.2.3)


### PR DESCRIPTION
attr_encrypted finally supports Rails 7